### PR TITLE
support serializing complex attributes to types other than string

### DIFF
--- a/JSONAPI.Tests/Models/AttributeGrabBag.cs
+++ b/JSONAPI.Tests/Models/AttributeGrabBag.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using JSONAPI.Attributes;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace JSONAPI.Tests.Models
 {
@@ -7,6 +10,13 @@ namespace JSONAPI.Tests.Models
     {
         Value1 = 1,
         Value2 = 2
+    }
+
+    public class SampleComplexType
+    {
+        [JsonProperty("intProp")]
+        public Int32 IntProp { get; set; }
+        public string StringProp { get; set; }
     }
 
     public class AttributeGrabBag
@@ -48,5 +58,11 @@ namespace JSONAPI.Tests.Models
 
         [SerializeAsComplex]
         public string ComplexAttributeField { get; set; }
+
+        [SerializeAsComplex]
+        public SampleComplexType ToOneComplexTypeField { get; set; }
+
+        [SerializeAsComplex]
+        public virtual ICollection<SampleComplexType> ToManyComplexTypeField { get; set; }
     }
 }

--- a/JSONAPI/JSONAPI.csproj
+++ b/JSONAPI/JSONAPI.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Core\IEphemeralRelatedResourceReader.cs" />
     <Compile Include="Core\INamingConventions.cs" />
     <Compile Include="Core\IResourceTypeRegistrar.cs" />
+    <Compile Include="Core\ObjectComplexAttributeValueConverter.cs" />
     <Compile Include="Core\PathVisitor.cs" />
     <Compile Include="Core\ResourceTypeAttribute.cs" />
     <Compile Include="Core\ResourceTypeRegistrar.cs" />


### PR DESCRIPTION
Now you can do

```
public class MyDto
{
    [SerializeAsComplex]
    public SomeOtherClass MyOtherClass {get; set; }
}

public class SomeOtherClass
{
    [JsonProperty("foo-bar")]
    public string FooBar {get; set;}
}
```