### PR TITLE
allow property injection for formatters

### DIFF
--- a/JSONAPI/Json/LinkFormatter.cs
+++ b/JSONAPI/Json/LinkFormatter.cs
@@ -10,9 +10,17 @@ namespace JSONAPI.Json
     /// </summary>
     public class LinkFormatter : ILinkFormatter
     {
-        private readonly IMetadataFormatter _metadataFormatter;
+        private IMetadataFormatter _metadataFormatter;
         private const string HrefKeyName = "href";
         private const string MetaKeyName = "meta";
+
+        /// <summary>
+        /// Constructs a LinkFormatter
+        /// </summary>
+        public LinkFormatter()
+        {
+            
+        }
 
         /// <summary>
         /// Constructs a LinkFormatter
@@ -21,6 +29,23 @@ namespace JSONAPI.Json
         public LinkFormatter(IMetadataFormatter metadataFormatter)
         {
             _metadataFormatter = metadataFormatter;
+        }
+
+        /// <summary>
+        /// The formatter to use for metadata on the link object
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public IMetadataFormatter MetadataFormatter
+        {
+            get
+            {
+                return _metadataFormatter ?? (_metadataFormatter = new MetadataFormatter());
+            }
+            set
+            {
+                if (_metadataFormatter != null) throw new InvalidOperationException("This property can only be set once.");
+                _metadataFormatter = value;
+            }
         }
 
         public Task Serialize(ILink link, JsonWriter writer)
@@ -35,7 +60,7 @@ namespace JSONAPI.Json
                 writer.WritePropertyName(HrefKeyName);
                 writer.WriteValue(link.Href);
                 writer.WritePropertyName(MetaKeyName);
-                _metadataFormatter.Serialize(link.Metadata, writer);
+                MetadataFormatter.Serialize(link.Metadata, writer);
                 writer.WriteEndObject();
             }
             return Task.FromResult(0);

--- a/JSONAPI/Json/RelationshipObjectFormatter.cs
+++ b/JSONAPI/Json/RelationshipObjectFormatter.cs
@@ -16,9 +16,17 @@ namespace JSONAPI.Json
         private const string LinkageKeyName = "data";
         private const string MetaKeyName = "meta";
 
-        private readonly ILinkFormatter _linkFormatter;
-        private readonly IResourceLinkageFormatter _resourceLinkageFormatter;
-        private readonly IMetadataFormatter _metadataFormatter;
+        private ILinkFormatter _linkFormatter;
+        private IResourceLinkageFormatter _resourceLinkageFormatter;
+        private IMetadataFormatter _metadataFormatter;
+
+        /// <summary>
+        /// Creates a new RelationshipObjectFormatter
+        /// </summary>
+        public RelationshipObjectFormatter ()
+        {
+            
+        }
 
         /// <summary>
         /// Creates a new RelationshipObjectFormatter
@@ -28,6 +36,45 @@ namespace JSONAPI.Json
             _linkFormatter = linkFormatter;
             _resourceLinkageFormatter = resourceLinkageFormatter;
             _metadataFormatter = metadataFormatter;
+        }
+
+        private ILinkFormatter LinkFormatter
+        {
+            get
+            {
+                return _linkFormatter ?? (_linkFormatter = new LinkFormatter());
+            }
+            set
+            {
+                if (_linkFormatter != null) throw new InvalidOperationException("This property can only be set once.");
+                _linkFormatter = value;
+            }
+        }
+
+        private IResourceLinkageFormatter ResourceLinkageFormatter
+        {
+            get
+            {
+                return _resourceLinkageFormatter ?? (_resourceLinkageFormatter = new ResourceLinkageFormatter());
+            }
+            set
+            {
+                if (_resourceLinkageFormatter != null) throw new InvalidOperationException("This property can only be set once.");
+                _resourceLinkageFormatter = value;
+            }
+        }
+
+        private IMetadataFormatter MetadataFormatter
+        {
+            get
+            {
+                return _metadataFormatter ?? (_metadataFormatter = new MetadataFormatter());
+            }
+            set
+            {
+                if (_metadataFormatter != null) throw new InvalidOperationException("This property can only be set once.");
+                _metadataFormatter = value;
+            }
         }
 
         public Task Serialize(IRelationshipObject relationshipObject, JsonWriter writer)
@@ -60,12 +107,12 @@ namespace JSONAPI.Json
                 if (relationshipObject.SelfLink != null)
                 {
                     writer.WritePropertyName(SelfLinkKeyName);
-                    _linkFormatter.Serialize(relationshipObject.SelfLink, writer);
+                    LinkFormatter.Serialize(relationshipObject.SelfLink, writer);
                 }
                 if (relationshipObject.RelatedResourceLink != null)
                 {
                     writer.WritePropertyName(RelatedLinkKeyName);
-                    _linkFormatter.Serialize(relationshipObject.RelatedResourceLink, writer);
+                    LinkFormatter.Serialize(relationshipObject.RelatedResourceLink, writer);
                 }
 
                 writer.WriteEndObject();
@@ -80,7 +127,7 @@ namespace JSONAPI.Json
             if (relationshipObject.Linkage != null)
             {
                 writer.WritePropertyName(LinkageKeyName);
-                _resourceLinkageFormatter.Serialize(relationshipObject.Linkage, writer);
+                ResourceLinkageFormatter.Serialize(relationshipObject.Linkage, writer);
             }
         }
 
@@ -92,7 +139,7 @@ namespace JSONAPI.Json
             if (relationshipObject.Metadata != null)
             {
                 writer.WritePropertyName(MetaKeyName);
-                _metadataFormatter.Serialize(relationshipObject.Metadata, writer);
+                MetadataFormatter.Serialize(relationshipObject.Metadata, writer);
             }
         }
 
@@ -114,10 +161,10 @@ namespace JSONAPI.Json
                 switch (propertyName)
                 {
                     case LinkageKeyName:
-                        linkage = await _resourceLinkageFormatter.Deserialize(reader, currentPath + "/" + LinkageKeyName);
+                        linkage = await ResourceLinkageFormatter.Deserialize(reader, currentPath + "/" + LinkageKeyName);
                         break;
                     case MetaKeyName:
-                        metadata = await _metadataFormatter.Deserialize(reader, currentPath + "/" + MetaKeyName);
+                        metadata = await MetadataFormatter.Deserialize(reader, currentPath + "/" + MetaKeyName);
                         break;
                 }
             }

--- a/JSONAPI/Json/ResourceCollectionDocumentFormatter.cs
+++ b/JSONAPI/Json/ResourceCollectionDocumentFormatter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -11,14 +12,22 @@ namespace JSONAPI.Json
     /// </summary>
     public class ResourceCollectionDocumentFormatter : IResourceCollectionDocumentFormatter
     {
-        private readonly IResourceObjectFormatter _resourceObjectFormatter;
-        private readonly IMetadataFormatter _metadataFormatter;
+        private IResourceObjectFormatter _resourceObjectFormatter;
+        private IMetadataFormatter _metadataFormatter;
         private const string PrimaryDataKeyName = "data";
         private const string RelatedDataKeyName = "included";
         private const string MetaKeyName = "meta";
-        
+
         /// <summary>
-        /// Creates a SingleResourceDocumentFormatter
+        /// Creates a ResourceCollectionDocumentFormatter
+        /// </summary>
+        public ResourceCollectionDocumentFormatter()
+        {
+            
+        }
+
+        /// <summary>
+        /// Creates a ResourceCollectionDocumentFormatter
         /// </summary>
         /// <param name="resourceObjectFormatter"></param>
         /// <param name="metadataFormatter"></param>
@@ -26,6 +35,40 @@ namespace JSONAPI.Json
         {
             _resourceObjectFormatter = resourceObjectFormatter;
             _metadataFormatter = metadataFormatter;
+        }
+
+        /// <summary>
+        /// The formatter to use for resource objects found in this document
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public IResourceObjectFormatter ResourceObjectFormatter
+        {
+            get
+            {
+                return _resourceObjectFormatter ?? (_resourceObjectFormatter = new ResourceObjectFormatter());
+            }
+            set
+            {
+                if (_resourceObjectFormatter != null) throw new InvalidOperationException("This property can only be set once.");
+                _resourceObjectFormatter = value;
+            }
+        }
+
+        /// <summary>
+        /// The formatter to use for document-level metadata
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
+        public IMetadataFormatter MetadataFormatter
+        {
+            get
+            {
+                return _metadataFormatter ?? (_metadataFormatter = new MetadataFormatter());
+            }
+            set
+            {
+                if (_metadataFormatter != null) throw new InvalidOperationException("This property can only be set once.");
+                _metadataFormatter = value;
+            }
         }
 
         public Task Serialize(IResourceCollectionDocument document, JsonWriter writer)
@@ -37,7 +80,7 @@ namespace JSONAPI.Json
             writer.WriteStartArray();
             foreach (var resourceObject in document.PrimaryData)
             {
-                _resourceObjectFormatter.Serialize(resourceObject, writer);
+                ResourceObjectFormatter.Serialize(resourceObject, writer);
             }
             writer.WriteEndArray();
 
@@ -47,7 +90,7 @@ namespace JSONAPI.Json
                 writer.WriteStartArray();
                 foreach (var resourceObject in document.RelatedData)
                 {
-                    _resourceObjectFormatter.Serialize(resourceObject, writer);
+                    ResourceObjectFormatter.Serialize(resourceObject, writer);
                 }
                 writer.WriteEndArray();
             }
@@ -55,7 +98,7 @@ namespace JSONAPI.Json
             if (document.Metadata != null)
             {
                 writer.WritePropertyName(MetaKeyName);
-                _metadataFormatter.Serialize(document.Metadata, writer);
+                MetadataFormatter.Serialize(document.Metadata, writer);
             }
 
             writer.WriteEndObject();
@@ -91,7 +134,7 @@ namespace JSONAPI.Json
                         primaryData = await DeserializePrimaryData(reader, currentPath + "/" + PrimaryDataKeyName);
                         break;
                     case MetaKeyName:
-                        metadata = await _metadataFormatter.Deserialize(reader, currentPath + "/" + MetaKeyName);
+                        metadata = await MetadataFormatter.Deserialize(reader, currentPath + "/" + MetaKeyName);
                         break;
                     default:
                         reader.Skip();
@@ -115,7 +158,7 @@ namespace JSONAPI.Json
                 if (reader.TokenType == JsonToken.EndArray)
                     break;
 
-                var resourceObject = await _resourceObjectFormatter.Deserialize(reader, currentPath + "/" + index);
+                var resourceObject = await ResourceObjectFormatter.Deserialize(reader, currentPath + "/" + index);
                 primaryData.Add(resourceObject);
 
                 index++;


### PR DESCRIPTION
The JSONAPI.JSON formatting classes are good candidates for property injection because there are acceptable local defaults. This will make it easier to instantiate ad hoc formatters - no need to new() up 10 different objects.