### PR TITLE
add HttpRequestMessage to DeleteRecord handler

### DIFF
--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/DocumentMaterializers/StarshipDocumentMaterializer.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/DocumentMaterializers/StarshipDocumentMaterializer.cs
@@ -62,7 +62,7 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.DocumentMaterializer
             throw new NotImplementedException();
         }
 
-        public override Task<IJsonApiDocument> DeleteRecord(string id, CancellationToken cancellationToken)
+        public override Task<IJsonApiDocument> DeleteRecord(string id, HttpRequestMessage request, CancellationToken cancellationToken)
         {
             throw new NotImplementedException();
         }

--- a/JSONAPI.EntityFramework/Http/EntityFrameworkDocumentMaterializer.cs
+++ b/JSONAPI.EntityFramework/Http/EntityFrameworkDocumentMaterializer.cs
@@ -86,7 +86,7 @@ namespace JSONAPI.EntityFramework.Http
             return returnDocument;
         }
 
-        public virtual async Task<IJsonApiDocument> DeleteRecord(string id, CancellationToken cancellationToken)
+        public virtual async Task<IJsonApiDocument> DeleteRecord(string id, HttpRequestMessage request, CancellationToken cancellationToken)
         {
             var singleResource = await _dbContext.Set<T>().FindAsync(cancellationToken, id);
             _dbContext.Set<T>().Remove(singleResource);

--- a/JSONAPI/Http/IDocumentMaterializer.cs
+++ b/JSONAPI/Http/IDocumentMaterializer.cs
@@ -39,6 +39,6 @@ namespace JSONAPI.Http
         /// <summary>
         /// Deletes the record corresponding to the given id.
         /// </summary>
-        Task<IJsonApiDocument> DeleteRecord(string id, CancellationToken cancellationToken);
+        Task<IJsonApiDocument> DeleteRecord(string id, HttpRequestMessage request, CancellationToken cancellationToken);
     }
 }

--- a/JSONAPI/Http/JsonApiController.cs
+++ b/JSONAPI/Http/JsonApiController.cs
@@ -78,7 +78,7 @@ namespace JSONAPI.Http
         public virtual async Task<IHttpActionResult> Delete(string resourceType, string id, CancellationToken cancellationToken)
         {
             var materializer = _documentMaterializerLocator.GetMaterializerByResourceTypeName(resourceType);
-            var document = await materializer.DeleteRecord(id, cancellationToken);
+            var document = await materializer.DeleteRecord(id, Request, cancellationToken);
             return Ok(document);
         }
     }

--- a/JSONAPI/Http/MappedDocumentMaterializer.cs
+++ b/JSONAPI/Http/MappedDocumentMaterializer.cs
@@ -102,8 +102,8 @@ namespace JSONAPI.Http
             HttpRequestMessage request,
             CancellationToken cancellationToken);
 
-        public abstract Task<IJsonApiDocument> DeleteRecord(string id, CancellationToken cancellationToken);
-
+        public abstract Task<IJsonApiDocument> DeleteRecord(string id, HttpRequestMessage request, CancellationToken cancellationToken);
+        
         /// <summary>
         /// Returns a list of property paths to be included when constructing a query for this resource type
         /// </summary>


### PR DESCRIPTION
On `IDocumentMaterializer`, `DeleteRecord` is the only method that does not accept an HttpRequestMessage parameter. For scenarios where you really need access to the the request in response to a DELETE, there is no other alternative. This is a breaking change, but it should be a relatively easy mechanical refactor.