### PR TITLE
Fix to allow filtering to work with entities that have integer keys

### DIFF
--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Data/Child.csv
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Data/Child.csv
@@ -1,0 +1,7 @@
+﻿Id,ChildDescription,MasterId
+7500,"Child 1 Description",1500
+7501,"Child 2 Description",1501
+7502,"Child 3 Description",1501
+7503,"Child 4 Description",1503
+7504,"Child 5 Description",1503
+7505,"Child 6 Description",1503

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Data/Master.csv
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Data/Master.csv
@@ -1,0 +1,5 @@
+﻿Id,Description
+1500,"Master 1 Description"
+1501,"Master 2 Description"
+1502,"Master 3 Description"
+1503,"Master 4 Description"

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/FetchingResourcesTests.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/FetchingResourcesTests.cs
@@ -183,5 +183,18 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests
                     HttpStatusCode.OK);
             }
         }
+
+        [TestMethod]
+        [DeploymentItem(@"Data\Master.csv", @"Data")]
+        [DeploymentItem(@"Data\Child.csv", @"Data")]
+        public async Task Get_related_to_many_integer_key()
+        {
+            using (var effortConnection = GetEffortConnection())
+            {
+                var response = await SubmitGet(effortConnection, "masters/1501/children");
+                                                                   
+                await AssertResponseContent(response, @"Fixtures\FetchingResources\Get_related_to_many_integer_key_response.json", HttpStatusCode.OK);
+            }
+        }
     }
 }

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/FetchingResources/Get_related_to_many_integer_key_response.json
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/FetchingResources/Get_related_to_many_integer_key_response.json
@@ -1,0 +1,34 @@
+﻿{
+    "data": [
+        {
+            "type": "children",
+            "id": "7501",
+            "attributes": {
+                "child-description": "Child 2 Description"
+            },
+            "relationships": {
+                "master": {
+                    "links": {
+                        "self": "https://www.example.com/children/7501/relationships/master",
+                        "related": "https://www.example.com/children/7501/master"
+                    }
+                }
+            }
+        },
+        {
+            "type": "children",
+            "id": "7502",
+            "attributes": {
+                "child-description": "Child 3 Description"
+            },
+            "relationships": {
+                "master": {
+                    "links": {
+                        "self": "https://www.example.com/children/7502/relationships/master",
+                        "related": "https://www.example.com/children/7502/master"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests.csproj
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests.csproj
@@ -123,6 +123,12 @@
     <EmbeddedResource Include="Fixtures\CreatingResources\Responses\Post_with_client_provided_id_Response.json" />
     <EmbeddedResource Include="Fixtures\CreatingResources\Responses\Post_with_empty_id_Response.json" />
     <None Include="App.config" />
+    <None Include="Data\Child.csv">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Data\Master.csv">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Data\Officer.csv">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -233,6 +239,7 @@
     <EmbeddedResource Include="Fixtures\Mapped\Responses\Get_resource_by_id_that_doesnt_exist.json" />
     <EmbeddedResource Include="Fixtures\Mapped\Responses\Get_related_to_one_response.json" />
     <EmbeddedResource Include="Fixtures\Mapped\Responses\Get_related_to_many_response.json" />
+    <EmbeddedResource Include="Fixtures\FetchingResources\Get_related_to_many_integer_key_response.json" />
     <None Include="packages.config" />
   </ItemGroup>
   <Choose>

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.csproj
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.csproj
@@ -131,10 +131,12 @@
     <Compile Include="DocumentMaterializers\StarshipShipCounselorRelatedResourceMaterializer.cs" />
     <Compile Include="DocumentMaterializers\StarshipOfficersRelatedResourceMaterializer.cs" />
     <Compile Include="Models\Building.cs" />
+    <Compile Include="Models\Child.cs" />
     <Compile Include="Models\Comment.cs" />
     <Compile Include="Models\Company.cs" />
     <Compile Include="Models\Language.cs" />
     <Compile Include="Models\LanguageUserLink.cs" />
+    <Compile Include="Models\Master.cs" />
     <Compile Include="Models\Officer.cs" />
     <Compile Include="Models\Post.cs" />
     <Compile Include="Models\Sample.cs" />

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/Models/Child.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/Models/Child.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Newtonsoft.Json;
+
+namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Models
+{
+    public class Child
+    {
+        public int Id { get; set; }
+
+        public string ChildDescription { get; set; }
+
+        [Required]
+        [JsonIgnore]
+        public int MasterId { get; set; }
+
+        [ForeignKey("MasterId")]
+        public Master Master { get; set; }
+    }
+}

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/Models/Master.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/Models/Master.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Models
+{
+    public class Master
+    {
+        public int Id { get; set; }
+
+        public string Description { get; set; }
+
+        public virtual ICollection<Child> Children { get; set; }
+    }
+}

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/Models/TestDbContext.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/Models/TestDbContext.cs
@@ -47,5 +47,7 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Models
         public DbSet<StarshipClass> StarshipClasses { get; set; }
         public DbSet<Officer> Officers { get; set; }
         public DbSet<StarshipOfficerLink> StarshipOfficerLinks { get; set; }
+        public DbSet<Master> Masters { get; set; }
+        public DbSet<Child> Children { get; set; }
     }
 }

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/Startup.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/Startup.cs
@@ -13,6 +13,7 @@ using JSONAPI.Configuration;
 using JSONAPI.EntityFramework;
 using JSONAPI.EntityFramework.Configuration;
 using Owin;
+using System.Collections.Generic;
 
 namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp
 {
@@ -33,7 +34,9 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp
 
         public void Configuration(IAppBuilder app)
         {
-            var configuration = new JsonApiConfiguration();
+            var configuration = new JsonApiConfiguration(
+                new Core.PluralizationService( 
+                    new Dictionary<string, string> { { "Child", "Children" } }));
             configuration.RegisterEntityFrameworkResourceType<Building>();
             configuration.RegisterEntityFrameworkResourceType<City>();
             configuration.RegisterEntityFrameworkResourceType<Comment>();
@@ -58,6 +61,8 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp
                     rc => rc.UseMaterializer<StarshipShipCounselorRelatedResourceMaterializer>());
             }); // Example of a resource that is mapped from a DB entity
             configuration.RegisterResourceType<StarshipOfficerDto>();
+            configuration.RegisterEntityFrameworkResourceType<Master>();
+            configuration.RegisterEntityFrameworkResourceType<Child>();
 
             var configurator = new JsonApiHttpAutofacConfigurator();
             configurator.OnApplicationLifetimeScopeCreating(builder =>

--- a/JSONAPI/Core/ResourceTypeRegistrar.cs
+++ b/JSONAPI/Core/ResourceTypeRegistrar.cs
@@ -77,7 +77,7 @@ namespace JSONAPI.Core
                 filterByIdFactory = (param, id) =>
                 {
                     var propertyExpr = Expression.Property(param, idProperty);
-                    var idExpr = Expression.Constant(id);
+                    var idExpr = Expression.Constant(Convert.ChangeType(id, idProperty.PropertyType));
                     return Expression.Equal(propertyExpr, idExpr);
                 };
             }


### PR DESCRIPTION
This is a very simple and possibly not optimal fix to allow filtering with entities that have integer keys.

I've added a test case that demonstrates the problem so hopefully you can either use this fix or achieve the same effect another way