### PR TITLE
bugfix: includes (eager-loading) must be applied to related not to primary resource!

### DIFF
--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/FetchingResourcesTests.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/FetchingResourcesTests.cs
@@ -116,6 +116,23 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests
             }
         }
 
+
+        [TestMethod]
+        [DeploymentItem(@"Data\Comment.csv", @"Data")]
+        [DeploymentItem(@"Data\Post.csv", @"Data")]
+        [DeploymentItem(@"Data\PostTagLink.csv", @"Data")]
+        [DeploymentItem(@"Data\Tag.csv", @"Data")]
+        [DeploymentItem(@"Data\User.csv", @"Data")]
+        public async Task Get_related_to_many_included_external()
+        {
+            using (var effortConnection = GetEffortConnection())
+            {
+                var response = await SubmitGet(effortConnection, "users/401/posts?include=tags");
+
+                await AssertResponseContent(response, @"Fixtures\FetchingResources\Get_related_to_many_include_external_response.json", HttpStatusCode.OK);
+            }
+        }
+
         [TestMethod]
         [DeploymentItem(@"Data\Comment.csv", @"Data")]
         [DeploymentItem(@"Data\Post.csv", @"Data")]

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/FetchingResources/Get_related_to_many_include_external_response.json
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/FetchingResources/Get_related_to_many_include_external_response.json
@@ -1,0 +1,164 @@
+{
+  "data": [
+    {
+      "type": "posts",
+      "id": "201",
+      "attributes": {
+        "content": "Post 1 content",
+        "created": "2015-01-31T14:00:00.0000000+00:00",
+        "title": "Post 1"
+      },
+      "relationships": {
+        "author": {
+          "links": {
+            "self": "https://www.example.com/posts/201/relationships/author",
+            "related": "https://www.example.com/posts/201/author"
+          }
+        },
+        "comments": {
+          "links": {
+            "self": "https://www.example.com/posts/201/relationships/comments",
+            "related": "https://www.example.com/posts/201/comments"
+          }
+        },
+        "tags": {
+          "links": {
+            "self": "https://www.example.com/posts/201/relationships/tags",
+            "related": "https://www.example.com/posts/201/tags"
+          },
+          "data": [
+            {
+              "type": "tags",
+              "id": "301"
+            },
+            {
+              "type": "tags",
+              "id": "302"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "posts",
+      "id": "202",
+      "attributes": {
+        "content": "Post 2 content",
+        "created": "2015-02-05T08:10:00.0000000+00:00",
+        "title": "Post 2"
+      },
+      "relationships": {
+        "author": {
+          "links": {
+            "self": "https://www.example.com/posts/202/relationships/author",
+            "related": "https://www.example.com/posts/202/author"
+          }
+        },
+        "comments": {
+          "links": {
+            "self": "https://www.example.com/posts/202/relationships/comments",
+            "related": "https://www.example.com/posts/202/comments"
+          }
+        },
+        "tags": {
+          "links": {
+            "self": "https://www.example.com/posts/202/relationships/tags",
+            "related": "https://www.example.com/posts/202/tags"
+          },
+          "data": [
+            {
+              "type": "tags",
+              "id": "302"
+            },
+            {
+              "type": "tags",
+              "id": "303"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "posts",
+      "id": "203",
+      "attributes": {
+        "content": "Post 3 content",
+        "created": "2015-02-07T11:11:00.0000000+00:00",
+        "title": "Post 3"
+      },
+      "relationships": {
+        "author": {
+          "links": {
+            "self": "https://www.example.com/posts/203/relationships/author",
+            "related": "https://www.example.com/posts/203/author"
+          }
+        },
+        "comments": {
+          "links": {
+            "self": "https://www.example.com/posts/203/relationships/comments",
+            "related": "https://www.example.com/posts/203/comments"
+          }
+        },
+        "tags": {
+          "links": {
+            "self": "https://www.example.com/posts/203/relationships/tags",
+            "related": "https://www.example.com/posts/203/tags"
+          },
+          "data": [
+            {
+              "type": "tags",
+              "id": "303"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "type": "tags",
+      "id": "301",
+      "attributes": {
+        "name": "Tag A"
+      },
+      "relationships": {
+        "posts": {
+          "links": {
+            "self": "https://www.example.com/tags/301/relationships/posts",
+            "related": "https://www.example.com/tags/301/posts"
+          }
+        }
+      }
+    },
+    {
+      "type": "tags",
+      "id": "302",
+      "attributes": {
+        "name": "Tag B"
+      },
+      "relationships": {
+        "posts": {
+          "links": {
+            "self": "https://www.example.com/tags/302/relationships/posts",
+            "related": "https://www.example.com/tags/302/posts"
+          }
+        }
+      }
+    },
+    {
+      "type": "tags",
+      "id": "303",
+      "attributes": {
+        "name": "Tag C"
+      },
+      "relationships": {
+        "posts": {
+          "links": {
+            "self": "https://www.example.com/tags/303/relationships/posts",
+            "related": "https://www.example.com/tags/303/posts"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests.csproj
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests.csproj
@@ -280,6 +280,7 @@
     <EmbeddedResource Include="Fixtures\Pagination\GetFilterPaged-2-1.json" />
     <EmbeddedResource Include="Fixtures\Pagination\GetFilterPaged-1-2-sorted.json" />
     <EmbeddedResource Include="Fixtures\Pagination\GetFilterPaged-1-2-sorted-desc.json" />
+    <EmbeddedResource Include="Fixtures\FetchingResources\Get_related_to_many_include_external_response.json" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />


### PR DESCRIPTION
I found an error in my implementation of eager loading on `EntityFrameworkToManyRelatedResourceDocumentMaterializer` which unfortunately was not coverd by a test with a resource which is nor related to primary.